### PR TITLE
Build geoserver.war from vendor/geoserver

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/geoserver"]
+	path = vendor/geoserver
+	url = git@github.com:koordinates/geoserver-plus-kx.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,15 +58,15 @@ FROM tomcat as download
 
 ARG GS_VERSION=2.25.1
 ARG GS_BUILD=release
-ARG WAR_ZIP_URL=https://downloads.sourceforge.net/project/geoserver/GeoServer/${GS_VERSION}/geoserver-${GS_VERSION}-war.zip
+ARG WAR_FILE=vendor/geoserver/src/web/app/target/geoserver.war
 ENV GEOSERVER_VERSION=$GS_VERSION
 ENV GEOSERVER_BUILD=$GS_BUILD
 
 WORKDIR /tmp
 
-RUN echo "Downloading GeoServer ${GS_VERSION} ${GS_BUILD}" \
-    && wget -q -O /tmp/geoserver.zip $WAR_ZIP_URL \
-    && unzip geoserver.zip geoserver.war -d /tmp/ \
+COPY ${WAR_FILE} /tmp/geoserver.war
+
+RUN echo "Extracting /tmp/geoserver.war (from ${WAR_FILE})" \
     && unzip -q /tmp/geoserver.war -d /tmp/geoserver \
     && rm /tmp/geoserver.war
 

--- a/KOORDINATES.md
+++ b/KOORDINATES.md
@@ -1,0 +1,21 @@
+# Build geoserver.war
+(at `vendor/geoserver/src/web/app/target/geoserver.war`):
+
+```shell
+mvn clean install -f vendor/geoserver/src -Dmaven.test.skip=true
+```
+
+(tests are currently failing due to koordinates-applicationContext.xml)
+
+# Build docker image
+
+```shell
+docker build -t {YOUR_TAG} .
+```
+
+# Run
+
+```shell
+docker run -it -p 80:8080 {YOUR_TAG}
+```
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This README.md file covers official geoserver builds. See [KOORDINATES.md](KOORDINATES.md)
+
 # A geoserver docker image
 
 This Dockerfile can be used to create images for all geoserver versions since 2.5.


### PR DESCRIPTION
... don't download a war.zip from anywhere.

Goes with https://github.com/koordinates/geoserver/pull/11

Proof of concept - may or may not be the right structure. But at least, pretty maintainable in that it's very similar to the original geoserver/docker.